### PR TITLE
Cleanup

### DIFF
--- a/packages/dev/viewer-web/src/viewer.ts
+++ b/packages/dev/viewer-web/src/viewer.ts
@@ -1,5 +1,5 @@
 import { AbstractEngine, Engine, Nullable } from "@babylonjs/core";
-import { MiniViewer, ViewerOptions as BaseViewerOptions } from "@babylonjs/viewer2";
+import { Viewer, ViewerOptions as BaseViewerOptions } from "@babylonjs/viewer2";
 
 type ViewerOptions = BaseViewerOptions & ({
     engine: AbstractEngine;
@@ -8,18 +8,18 @@ type ViewerOptions = BaseViewerOptions & ({
     antialias?: boolean;
 });
 
-export function createViewer(options: ViewerOptions): MiniViewer {
+export function createViewer(options: ViewerOptions): Viewer {
     if ("engine" in options) {
-        return new MiniViewer(options.engine, options);
+        return new Viewer(options.engine, options);
     } else {
-        return new MiniViewer(new Engine(options.canvas, options.antialias), options);
+        return new Viewer(new Engine(options.canvas, options.antialias), options);
     }
 }
 
 export class HTML3DElement extends HTMLElement {
   public static readonly observedAttributes = Object.freeze(["src", "env"] as const);
 
-  private readonly viewer: MiniViewer;
+  private readonly viewer: Viewer;
 
   public constructor() {
     super();

--- a/packages/dev/viewer-web/src/viewer.ts
+++ b/packages/dev/viewer-web/src/viewer.ts
@@ -1,19 +1,14 @@
-import { AbstractEngine, Engine, Nullable } from "@babylonjs/core";
-import { Viewer, ViewerOptions as BaseViewerOptions } from "@babylonjs/viewer2";
+import { Engine, EngineOptions, Logger, Nullable } from "@babylonjs/core";
+import { Viewer, ViewerOptions } from "@babylonjs/viewer2";
 
-type ViewerOptions = BaseViewerOptions & ({
-    engine: AbstractEngine;
-} | {
-    canvas: HTMLCanvasElement;
-    antialias?: boolean;
-});
+export function createViewerForCanvas(canvas: HTMLCanvasElement, options?: ViewerOptions & EngineOptions): Viewer {
+    const engine = new Engine(canvas, undefined, options);
+    const viewer = new Viewer(engine, options);
 
-export function createViewer(options: ViewerOptions): Viewer {
-    if ("engine" in options) {
-        return new Viewer(options.engine, options);
-    } else {
-        return new Viewer(new Engine(options.canvas, options.antialias), options);
-    }
+    // TODO: register for viewer.onDisposeObservable and dispose engine instance
+    // TODO: use ResizeObserver to monitor canvas and update width/height and resize engine (maybe something like https://webgpufundamentals.org/webgpu/lessons/webgpu-resizing-the-canvas.html)
+
+    return viewer;
 }
 
 export class HTML3DElement extends HTMLElement {
@@ -51,7 +46,7 @@ export class HTML3DElement extends HTMLElement {
     </div>`;
 
     const canvas = shadowRoot.querySelector("#renderCanvas") as HTMLCanvasElement;
-    this.viewer = createViewer({ canvas });
+    this.viewer = createViewerForCanvas(canvas);
   }
 
   public get src() {
@@ -72,10 +67,10 @@ export class HTML3DElement extends HTMLElement {
   public attributeChangedCallback(name: typeof HTML3DElement.observedAttributes[number], oldValue: string, newValue: string) {
     switch(name) {
         case "src":
-            this.viewer.loadModelAsync(newValue);
+            this.viewer.loadModelAsync(newValue).catch(Logger.Error);
             break;
         case "env":
-            this.viewer.loadEnvironmentAsync(newValue);
+            this.viewer.loadEnvironmentAsync(newValue).catch(Logger.Error);
             break;
     }
   }

--- a/packages/dev/viewer/src/asyncLock.ts
+++ b/packages/dev/viewer/src/asyncLock.ts
@@ -1,0 +1,24 @@
+/**
+ * Provides a simple way of creating the rough equivalent of an async critical section.
+ *
+ * @description
+ * AsyncLock can be used to sequentialize async operations (ensure they don't overlap).
+ *
+ * @example
+ * const myLock = new AsyncLock();
+ *
+ * private async MyFuncAsync(): Promise<void> {
+ *   await myLock.LockAsync(async () => {
+ *     await operation1Async();
+ *     await operation2Async();
+ *   });
+ * }
+ */
+export class AsyncLock {
+    private currentOperation: Promise<unknown> = Promise.resolve();
+    public lockAsync<T>(func: () => T | Promise<T>): Promise<T> {
+        const newOperation = this.currentOperation.then(func, func);
+        this.currentOperation = newOperation;
+        return newOperation;
+    }
+}

--- a/packages/dev/viewer/src/index.ts
+++ b/packages/dev/viewer/src/index.ts
@@ -1,1 +1,1 @@
-export * from './miniViewer';
+export * from './viewer';

--- a/packages/dev/viewer/src/viewer.ts
+++ b/packages/dev/viewer/src/viewer.ts
@@ -34,9 +34,9 @@ function createDefaultSkybox(scene: Scene, reflectionTexture: BaseTexture, scale
 
 export const defaultViewerOptions = {
     backgroundColor: new Color4(0.1, 0.1, 0.2, 1.0),
-};
+} as const;
 
-export type ViewerOptions = Readonly<Partial<typeof defaultViewerOptions>>;
+export type ViewerOptions = Partial<typeof defaultViewerOptions>;
 
 export class Viewer implements IDisposable
 {

--- a/packages/dev/viewer/src/viewer.ts
+++ b/packages/dev/viewer/src/viewer.ts
@@ -38,7 +38,7 @@ export const defaultViewerOptions = {
 
 export type ViewerOptions = Readonly<Partial<typeof defaultViewerOptions>>;
 
-export class MiniViewer implements IDisposable
+export class Viewer implements IDisposable
 {
     private readonly scene: Scene;
     private readonly camera: ArcRotateCamera;

--- a/packages/test/apps/web/public/index.html
+++ b/packages/test/apps/web/public/index.html
@@ -33,6 +33,8 @@
       setTimeout(() => {
         //console.log('Changing model');
         viewer.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb';
+        // error case
+        //viewer.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb';
       }, 2000);
     </script>
   </body>

--- a/packages/test/apps/web/public/index.html
+++ b/packages/test/apps/web/public/index.html
@@ -33,7 +33,7 @@
       setTimeout(() => {
         //console.log('Changing model');
         viewer.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb';
-      }, 0);
+      }, 2000);
     </script>
   </body>
 </html>

--- a/packages/test/apps/web/public/index.html
+++ b/packages/test/apps/web/public/index.html
@@ -23,7 +23,17 @@
   </head>
 
   <body>
-    <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env"></babylon-viewer>
+    <babylon-viewer
+      src="https://playground.babylonjs.com/scenes/BoomBox.glb"
+      env="https://assets.babylonjs.com/environments/ulmerMuenster.env">
+    </babylon-viewer>
   	<script src="webtest.js"></script>
+    <script>
+      const viewer = document.querySelector('babylon-viewer');
+      setTimeout(() => {
+        //console.log('Changing model');
+        viewer.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb';
+      }, 0);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Move `canvas` handling out of the pure JS layer
- Add `AsyncLock` and use it to sequentialize async loads (model and env)
- Move env loading to an explicit function so the `env` attribute on the custom element can change
- Add cleanup logic for previous model and/or previous env
- Allow `src` and `env` attributes to change at runtime